### PR TITLE
FIX: make authUsing nullable (#354)

### DIFF
--- a/src/Totem.php
+++ b/src/Totem.php
@@ -18,7 +18,7 @@ class Totem
      *
      * @var Closure
      */
-    public static Closure $authUsing;
+    public static ?Closure $authUsing = null;
 
     /**
      * Determine if the given request can access the Totem dashboard.


### PR DESCRIPTION
`authUsing` needs to be nullable in order to prevent `accessed before initialization` error.

Fixes #354